### PR TITLE
Improve pretty-printing to support invalid bitflags

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,16 +1,26 @@
 name: CompatHelper
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 48 16 * * *
   workflow_dispatch:
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: "Install CompatHelper"
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+        shell: julia --color=yes {0}
+      - name: "Run CompatHelper"
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+          # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}

--- a/.github/workflows/RegisterAction.yml
+++ b/.github/workflows/RegisterAction.yml
@@ -1,0 +1,14 @@
+name: RegisterAction
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to register or component to bump
+        required: true
+jobs:
+  register:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/RegisterAction@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,28 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - 'master'
+    tags: '*'
+    paths-ignore:
+      - 'README.md'
+      - '.github/workflows/**'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - '.github/workflows/**'
+
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.0'     # earliest supported
-          - '1.5'     # latest release
+          - '1'       # latest release
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitFlags"
 uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
-authors = ["Justin Willmert <justin@jdjlab.com>"]
-version = "0.1.3"
+authors = ["Justin Willmert <justin@willmert.me>"]
+version = "0.1.4"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
This may occur when values are reinterpreted from raw integers.
Rather than printing a chain of ORs which do not sum to the explicit
value (or worse yet, print nothing for a disjoint bitset), just tack
on to the end of the chain the explicit numerical value of all
unhandled bits.
    
We can even represent this in the non-compact case as a reinterpret
expression which is copy-pastable to re-form the given value.