### PR TITLE
Improve efficiency and speed of the macro expansion

### DIFF
--- a/src/BitFlags.jl
+++ b/src/BitFlags.jl
@@ -164,7 +164,7 @@ function _bitflag(__module__::Module, T::Union{Symbol, Expr}, x::Vector{Any})
         end
         basetype = baseexpr::Type{<:Unsigned}
     else
-        _throw_error(typename, T)
+        _throw_error(T, "bad expression head")
     end
     if isempty(x)
         throw(ArgumentError("no arguments given for BitFlag $typename"))

--- a/src/BitFlags.jl
+++ b/src/BitFlags.jl
@@ -202,21 +202,20 @@ function _bitflag_impl(__module__::Module, typename::Symbol, basetype::Type{<:Un
             if (i == typemin(basetype)) && (maskother & typemax(basetype) != 0)
                 throw(ArgumentError("overflow in value \"$s\" of BitFlag $typename"))
             end
-            sym = s
-        elseif isexpr(s, (:(=), :kw), 2) && s.args[1] isa Symbol
-            i = Core.eval(__module__, s.args[2]) # allow exprs, e.g. uint128"1"
-            if !(i isa Integer)
+            sym = s::Symbol
+        elseif isexpr(s, (:(=), :kw), 2) && (e = s::Expr; e.args[1] isa Symbol)
+            sym = e.args[1]::Symbol
+            ei = Core.eval(__module__, e.args[2]) # allow exprs, e.g. uint128"1"
+            if !(ei isa Integer)
                 _throw_error(typename, s, "values must be unsigned integers")
             end
+            i = convert(basetype, ei)::basetype
             if !iszero(i) && !ispow2(i)
                 _throw_error(typename, s, "values must be a positive power of 2")
             end
-            i = convert(basetype, i)
-            sym = s.args[1]
         else
             _throw_error(typename, s)
         end
-        sym = sym::Symbol
         if !Base.isidentifier(sym)
             _throw_error(typename, s, "not a valid identifier")
         end

--- a/src/BitFlags.jl
+++ b/src/BitFlags.jl
@@ -83,9 +83,9 @@ function Base.show(io::IO, m::MIME"text/plain", t::Type{<:BitFlag})
         print(io, "BitFlag ")
         Base.show_datatype(io, t)
         print(io, ":")
-        for x in instances(t)
-            print(io, "\n", Symbol(x), " = ")
-            show(io, Integer(x))
+        for (i, sym) in namemap(t)
+            print(io, "\n", sym, " = ")
+            show(io, Integer(i))
         end
     else
         invoke(show, Tuple{IO, typeof(m), Type}, io, m, t)

--- a/src/BitFlags.jl
+++ b/src/BitFlags.jl
@@ -160,6 +160,10 @@ julia> instances(Items)
 ```
 """
 macro bitflag(T::Union{Symbol,Expr}, syms...)
+    return _bitflag(__module__, T, Any[syms...])
+end
+
+function _bitflag(__module__::Module, T::Union{Symbol, Expr}, syms::Vector{Any})
     if isempty(syms)
         throw(ArgumentError("no arguments given for BitFlag $T"))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,8 @@ end
 
     @test_throws ArgumentError("no arguments given for BitFlag Foo"
                               ) @macrocall(@bitflag Foo)
+    @test_throws ArgumentError("invalid argument for BitFlag Foo isa UInt32: bad expression head"
+                              ) @macrocall(@bitflag Foo isa UInt32)
     @test_throws ArgumentError("invalid argument for BitFlag Foo: Foo::Float64; "
                                * "base type must be a bitstype unsigned integer"
                               ) @macrocall(@bitflag Foo::Float64 x=1.)
@@ -103,6 +105,8 @@ end
                               ) @macrocall(@bitflag Foo x=1 y=1)
     @test_throws ArgumentError("invalid argument for BitFlag Foo: y = 0; value is not unique"
                               ) @macrocall(@bitflag Foo x=0 y=0)
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: x; name is not unique"
+                              ) @macrocall(@bitflag Foo x=0 x)
 
     # Explicit values must be powers of two
     @test_throws ArgumentError("invalid argument for BitFlag Foo: _three = 3; "
@@ -129,6 +133,9 @@ end
                               ) @macrocall(@bitflag Foo x ? 1 : 2)
     @test_throws ArgumentError("invalid argument for BitFlag Foo: 1 = 2"
                               ) @macrocall(@bitflag Foo 1=2)
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: #1; "
+                               * "not a valid identifier"
+                              ) @eval @macrocall(@bitflag Foo $(Symbol("#1")))
 
     # Disallow value overflow
     @test_throws ArgumentError("overflow in value \"y\" of BitFlag Foo"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,30 +94,29 @@ end
 
     @test_throws ArgumentError("no arguments given for BitFlag Foo"
                               ) @macrocall(@bitflag Foo)
-    @test_throws ArgumentError("invalid base type for BitFlag Foo, "
-                               * "::Float64; base type must be an unsigned "
-                               * "integer primitive type"
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: Foo::Float64; "
+                               * "base type must be a bitstype unsigned integer"
                               ) @macrocall(@bitflag Foo::Float64 x=1.)
 
     # Require uniqueness
-    @test_throws ArgumentError("values for BitFlag Foo are not unique"
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: y = 1; value is not unique"
                               ) @macrocall(@bitflag Foo x=1 y=1)
-    @test_throws ArgumentError("values for BitFlag Foo are not unique"
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: y = 0; value is not unique"
                               ) @macrocall(@bitflag Foo x=0 y=0)
 
     # Explicit values must be powers of two
-    @test_throws ArgumentError("invalid value for BitFlag Foo, _three = 3; "
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: _three = 3; "
                                * "values must be a positive power of 2"
                               ) @macrocall(@bitflag Foo _three = 3)
 
     # Values must be integers
-    @test_throws ArgumentError("invalid value for BitFlag Foo, _zero = \"zero\"; "
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: _zero = \"zero\"; "
                                * "values must be unsigned integers"
                               ) @macrocall(@bitflag Foo _zero="zero")
-    @test_throws ArgumentError("invalid value for BitFlag Foo, _zero = '0'; "
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: _zero = '0'; "
                                * "values must be unsigned integers"
                               ) @macrocall(@bitflag Foo _zero='0')
-    @test_throws ArgumentError("invalid value for BitFlag Foo, _zero = 0.5; "
+    @test_throws ArgumentError("invalid argument for BitFlag Foo: _zero = 0.5; "
                                * "values must be unsigned integers"
                               ) @macrocall(@bitflag Foo _zero=0.5)
 


### PR DESCRIPTION
This PR contains a number of code and performance improvements. (Commit f815fc1 by far dominates in the performance improvement.) In all, the time to generate bit flag definitions for a large-ish test case is reduced by about 35%.

The benchmarking script was generated with the code:
```julia
open("perf_many_bitflags.jl", "w") do fh                                                                                                                                                                                                      
    write(fh, "using BitFlags\n\n")                                                                                                                                                                                                           
                                                                                                                                                                                                                                              
    for ii in 1:16                                                                                                                                                                                                                            
        write(fh, "@bitflag InlineFlags$(ii)$(ii > 8 ? "::UInt64" : "")")                                                                                                                                                                     
        for jj in 1:3ii                                                                                                                                                                                                                       
            write(fh, " inlineflag$(ii)_$(jj)")                                                                                                                                                                                               
        end                                                                                                                                                                                                                                   
        write(fh, "\n\n")                                                                                                                                                                                                                     
    end                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
    for ii in 1:16                                                                                                                                                                                                                            
        write(fh, "@bitflag InlineFlags$(ii)", ii > 8 ? "::UInt64" : "", " begin\n")                                                                                                                                                          
        for jj in 1:3ii                                                                                                                                                                                                                       
            write(fh, "    blockflag$(ii)_$(jj)",                                                                                                                                                                                             
                      ii % 2 == 0 && jj == 1 ? " = Int8(0)" : "", "\n")                                                                                                                                                                       
        end                                                                                                                                                                                                                                   
        write(fh, "end\n\n")                                                                                                                                                                                                                  
    end                                                                                                                                                                                                                                       
end
```
Benchmarking an `include` into an empty module on multiple version of Julia (keeping just the minimum) produced the following graph. (0.1.5 is the base release before the first commit, and 0.1.5-9-* is the last commit in the PR.)

![faster_codegen](https://user-images.githubusercontent.com/2965436/201122685-a956e1fe-3a3c-4db6-9964-02b6c2561e61.svg)